### PR TITLE
Potential fix for code scanning alert no. 62: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.21",
     "nodemailer": "^6.9.15",
     "pg": "^8.13.1",
-    "sanitize-html": "^2.14.0"
+    "sanitize-html": "^2.14.0",
+    "dompurify": "^3.2.3"
   }
 }

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 //code for dashboard.html
 // Function to dynamically update the numbers next to the day names
 function updateDayNumbers() { // start of updateDayNumbers() function
@@ -76,7 +77,9 @@ function mapEventsToDays() { // start of mapEventsToDays() function
 
       // Update the table cell with the event information
       if (tableRow && tableRow.cells[1]) {
-        tableRow.cells[1].innerHTML = `<u>${event.title}</u><br>${event.time}`;
+        const sanitizedTitle = DOMPurify.sanitize(event.title);
+        const sanitizedTime = DOMPurify.sanitize(event.time);
+        tableRow.cells[1].innerHTML = `<u>${sanitizedTitle}</u><br>${sanitizedTime}`;
       }
     }
   });
@@ -86,8 +89,6 @@ function mapEventsToDays() { // start of mapEventsToDays() function
 document.addEventListener("DOMContentLoaded", () => {
   mapEventsToDays();
 });
-
-document.addEventListener("DOMContentLoaded", mapEventsToDays);
 
 mapEventsToDays();
 


### PR DESCRIPTION
Potential fix for [https://github.com/pobba-dud/We-Serve/security/code-scanning/62](https://github.com/pobba-dud/We-Serve/security/code-scanning/62)

To fix the problem, we need to ensure that any user-provided data is properly sanitized or escaped before being inserted into the HTML. This can be achieved by using a library like `DOMPurify` to sanitize the input or by manually escaping HTML special characters.

The best way to fix the problem without changing existing functionality is to use `DOMPurify` to sanitize the `event.title` and `event.time` before inserting them into the HTML. This ensures that any potentially malicious content is neutralized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
